### PR TITLE
added option to NOT expose JSON source in the exception message when …

### DIFF
--- a/src/main/java/org/stringtree/json/ExceptionErrorListener.java
+++ b/src/main/java/org/stringtree/json/ExceptionErrorListener.java
@@ -1,9 +1,23 @@
 package org.stringtree.json;
 
 public class ExceptionErrorListener extends BufferErrorListener {
-    
+    private boolean exposeJsonSource;
+
+    public ExceptionErrorListener() {
+        this(true);
+    }
+
+    public ExceptionErrorListener(boolean exposeJsonSource) {
+        this.exposeJsonSource = exposeJsonSource;
+    }
+
+    @Override
     public void error(String type, int col) {
-        super.error(type, col);
+        if (exposeJsonSource) {
+            super.error(type, col);
+        } else {
+            buffer.append("expected ").append(type).append(" at column ").append(col);
+        }
         throw new IllegalArgumentException(buffer.toString());
     }
 }

--- a/src/test/java/tests/json/ExceptionErrorListenerTest.java
+++ b/src/test/java/tests/json/ExceptionErrorListenerTest.java
@@ -1,0 +1,26 @@
+package tests.json;
+
+import org.stringtree.json.ExceptionErrorListener;
+import org.stringtree.json.JSONValidatingReader;
+
+import junit.framework.TestCase;
+
+public class ExceptionErrorListenerTest extends TestCase {
+    public void testExceptionMessageExposesJsonSource() {
+        try {
+            new JSONValidatingReader(new ExceptionErrorListener()).read("{invalid}");
+            fail("did not throw exception!");
+        } catch (IllegalArgumentException ex) {
+            assertTrue("JSON source not emitted!", ex.getMessage().contains("{invalid}"));
+        }
+    }
+
+    public void testExceptionMessageDoesNotExposeJsonSource() {
+        try {
+            new JSONValidatingReader(new ExceptionErrorListener(false)).read("{invalid}");
+            fail("did not throw exception!");
+        } catch (IllegalArgumentException ex) {
+            assertFalse("JSON source was emitted!", ex.getMessage().contains("{invalid}"));
+        }
+    }
+}

--- a/src/test/java/tests/json/JSONValidatorTests.java
+++ b/src/test/java/tests/json/JSONValidatorTests.java
@@ -14,6 +14,7 @@ public class JSONValidatorTests extends TestCase {
         suite.addTestSuite(JSONValidatorInvalidStringTest.class);
         suite.addTestSuite(JSONValidatorInvalidArrayTest.class);
         suite.addTestSuite(JSONValidatorInvalidObjectTest.class);
+        suite.addTestSuite(ExceptionErrorListenerTest.class);
 
         return suite;
     }


### PR DESCRIPTION
…ExceptionErrorListener throws an exception.

I've needed this change a number of times over the years in order to not "leak" information like email addresses, IDs, etc. in production application logs. Figured it was time to submit the change back.